### PR TITLE
Fixes DNS check to support search domain

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -510,7 +510,7 @@ def update_peer_default_config():
     # Check DNS Format
     DNS = request.form['peer_global_DNS']
     DNS = cleanIp(DNS)
-    if not checkIp(DNS):
+    if not checkIp(DNS.split(",")[0]):
         session['message'] = "Peer DNS Format Incorrect. Example: 1.1.1.1"
         session['message_status'] = "danger"
         return redirect(url_for("settings"))

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -768,8 +768,8 @@ def add_peer(config_name):
         return "Public key already exist."
     if len(db.search(peers.allowed_ip.matches(allowed_ips))) != 0:
         return "Allowed IP already taken by another peer."
-    if not checkIp(DNS):
-        return "DNS formate is incorrect. Example: 1.1.1.1"
+    if not checkIp(DNS.split(",")[0]):
+        return "DNS format is incorrect. Example: 1.1.1.1"
     if not checkAllowedIPs(endpoint_allowed_ip):
         return "Endpoint Allowed IPs format is incorrect."
     else:


### PR DESCRIPTION
Wireguard supports passing the search domain in the DNS field like "DNS=1.1.1.1,davejlong.com" as seen in the man page for wg-quick:

> DNS — a comma-separated list of IP (v4 or v6) addresses to be set as the interface's DNS servers, or non-IP hostnames to be set as the interface's DNS search domains. May be specified multiple times. Upon bringing the interface up, this runs `resolvconf -a tun.INTERFACE -m 0 -x` and upon bringing it down, this runs `resolvconf -d tun.INTERFACE`. If these particular invocations of resolvconf(8) are undesirable, the PostUp and PostDown keys below may be used instead.

https://manpages.debian.org/unstable/wireguard-tools/wg-quick.8.en.html

This pull request isn't a perfect solution but it splits the string passed to the DNS input and only checks the first string as an IP address. A better solution would be to split the string on commas and check each string as a valid IP or DNS hostname.