### PR TITLE
Remote Peer, MTU and PersistentKeepalives added

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -805,10 +805,10 @@ def add_peer(config_name):
         return "Allowed IP already taken by another peer."
     if not checkIp(DNS):
         return "DNS format is incorrect. Example: 1.1.1.1"
-    if not checkAllowedIPs(endpoint_allowed_ip):
-        return "Endpoint Allowed IPs format is incorrect."
     if not validate(remote_endpoint):
         return "Remote peer incorrect"
+    if not checkAllowedIPs(endpoint_allowed_ip):
+        return "Endpoint Allowed IPs format is incorrect."
     else:
         status = ""
         try:

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -406,6 +406,7 @@ def validate(remoteEndpoint):
     if checkIp(remoteEndpoint):
         return True
     elif is_valid_hostname(remoteEndpoint):
+        print(f"Allowed = {is_valid_hostname(remoteEndpoint)}")
         return True
     else:
         return False

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -945,7 +945,6 @@ def download(config_name):
     peers = Query()
     print(id)
     get_peer = db.search(peers.id == id)
-    print(get_peer)
     if len(get_peer) == 1:
         peer = get_peer[0]
         if peer['private_key'] != "":

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -406,7 +406,6 @@ def validate(remoteEndpoint):
     if checkIp(remoteEndpoint):
         return True
     elif is_valid_hostname(remoteEndpoint):
-        print(f"Allowed = {is_valid_hostname(remoteEndpoint)}")
         return True
     else:
         return False

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -1019,9 +1019,6 @@ def download(config_name):
                 filename = "".join(filename.split(' '))
             filename = filename + "_" + config_name
 
-            print(f"Keepalive value = {keepalive}")
-            print(f"MTU value = {mtu}")
-
             if mtu != "" and keepalive == "":
                 print(f"Using MTU of {mtu} and a Keepalive value = {keepalive}")
                 def generate(private_key, allowed_ip, DNS, mtu, public_key, endpoint):

--- a/src/static/js/configuration.js
+++ b/src/static/js/configuration.js
@@ -210,8 +210,8 @@ $("#save_peer_setting").click(function (){
     $(this).attr("disabled","disabled")
     $(this).html("Saving...")
     if ($("#peer_DNS_textbox").val() !== "" &&
-        $("#peer_allowed_ip_textbox").val() !== "" &&
         $("#peer_remote_endpoint_textbox").val() !== "" &&
+        $("#peer_allowed_ip_textbox").val() !== "" &&
         $("#peer_endpoint_allowed_ips").val() != ""
     ){
         var peer_id = $(this).attr("peer_id");

--- a/src/static/js/configuration.js
+++ b/src/static/js/configuration.js
@@ -61,9 +61,9 @@ $("#save_peer").click(function(){
     $(this).attr("disabled","disabled")
     $(this).html("Saving...")
 
-    if ($("#allowed_ips").val() !== "" && $("#public_key").val() !== "" && $("#new_add_DNS").val() !== "" && $("#new_add_endpoint_allowed_ip").val() != ""){
+    if ($("#allowed_ips").val() !== "" && $("#public_key").val() !== "" && $("#new_add_DNS").val() !== "" && $("#new_add_remote_endpoint").val() !== "" && $("#new_add_endpoint_allowed_ip").val() != ""){
         var conf = $(this).attr('conf_id')
-        var data_list = [$("#private_key"), $("#allowed_ips"), $("#new_add_name"), $("#new_add_DNS"), $("#new_add_endpoint_allowed_ip")]
+        var data_list = [$("#private_key"), $("#allowed_ips"), $("#new_add_name"), $("#new_add_DNS"), $("#new_add_remote_endpoint"), $("#new_add_endpoint_allowed_ip")]
         for (var i = 0; i < data_list.length; i++){
             data_list[i].attr("disabled", "disabled")
         }
@@ -81,6 +81,7 @@ $("#save_peer").click(function(){
                 "allowed_ips": $("#allowed_ips").val(),
                 "name":$("#new_add_name").val(),
                 "DNS": $("#new_add_DNS").val(),
+                "remote_endpoint": $("#new_add_remote_endpoint").val(),
                 "endpoint_allowed_ip": $("#new_add_endpoint_allowed_ip").val()
             }),
             success: function (response){
@@ -171,6 +172,7 @@ $("body").on("click", ".btn-setting-peer", function(){
             $("#setting_modal #peer_name_textbox").val(peer_name)
             $("#setting_modal #peer_private_key_textbox").val(response['private_key'])
             $("#setting_modal #peer_DNS_textbox").val(response['DNS'])
+            $("#setting_modal #peer_remote_endpoint_textbox").val(response['remote_endpoint'])
             $("#setting_modal #peer_allowed_ip_textbox").val(response['allowed_ip'])
             $("#setting_modal #peer_endpoint_allowed_ips").val(response['endpoint_allowed_ip'])
             settingModal.toggle();
@@ -209,11 +211,12 @@ $("#save_peer_setting").click(function (){
     $(this).html("Saving...")
     if ($("#peer_DNS_textbox").val() !== "" &&
         $("#peer_allowed_ip_textbox").val() !== "" &&
+        $("#peer_remote_endpoint_textbox").val() !== "" &&
         $("#peer_endpoint_allowed_ips").val() != ""
     ){
         var peer_id = $(this).attr("peer_id");
         var conf_id = $(this).attr("conf_id");
-        var data_list = [$("#peer_name_textbox"), $("#peer_DNS_textbox"), $("#peer_private_key_textbox"), $("#peer_allowed_ip_textbox"), $("#peer_endpoint_allowed_ips")]
+        var data_list = [$("#peer_name_textbox"), $("#peer_DNS_textbox"), $("#peer_private_key_textbox"), $("#peer_remote_endpoint_textbox"), $("#peer_allowed_ip_textbox"), $("#peer_endpoint_allowed_ips")]
         for (var i = 0; i < data_list.length; i++){
             data_list[i].attr("disabled", "disabled")
         }
@@ -228,6 +231,7 @@ $("#save_peer_setting").click(function (){
                 name: $("#peer_name_textbox").val(),
                 DNS: $("#peer_DNS_textbox").val(),
                 private_key: $("#peer_private_key_textbox").val(),
+                remote_endpoint: $("#peer_remote_endpoint_textbox").val(),
                 allowed_ip: $("#peer_allowed_ip_textbox").val(),
                 endpoint_allowed_ip: $("#peer_endpoint_allowed_ips").val()
             }),

--- a/src/static/js/configuration.js
+++ b/src/static/js/configuration.js
@@ -63,7 +63,7 @@ $("#save_peer").click(function(){
 
     if ($("#allowed_ips").val() !== "" && $("#public_key").val() !== "" && $("#new_add_DNS").val() !== "" && $("#new_add_remote_endpoint").val() !== "" && $("#new_add_endpoint_allowed_ip").val() != ""){
         var conf = $(this).attr('conf_id')
-        var data_list = [$("#private_key"), $("#allowed_ips"), $("#new_add_name"), $("#new_add_DNS"), $("#new_add_remote_endpoint"), $("#new_add_endpoint_allowed_ip")]
+        var data_list = [$("#private_key"), $("#allowed_ips"), $("#new_add_name"), $("#new_add_DNS"), $("#new_add_remote_endpoint"), $("#new_add_mtu"), $("#new_add_keepalive"), $("#new_add_endpoint_allowed_ip")]
         for (var i = 0; i < data_list.length; i++){
             data_list[i].attr("disabled", "disabled")
         }
@@ -82,6 +82,8 @@ $("#save_peer").click(function(){
                 "name":$("#new_add_name").val(),
                 "DNS": $("#new_add_DNS").val(),
                 "remote_endpoint": $("#new_add_remote_endpoint").val(),
+                "mtu": $("#new_add_mtu").val(),
+                "keepalive": $("#new_add_keepalive").val(),
                 "endpoint_allowed_ip": $("#new_add_endpoint_allowed_ip").val()
             }),
             success: function (response){
@@ -173,6 +175,8 @@ $("body").on("click", ".btn-setting-peer", function(){
             $("#setting_modal #peer_private_key_textbox").val(response['private_key'])
             $("#setting_modal #peer_DNS_textbox").val(response['DNS'])
             $("#setting_modal #peer_remote_endpoint_textbox").val(response['remote_endpoint'])
+            $("#setting_modal #peer_mtu_textbox").val(response['mtu'])
+            $("#setting_modal #peer_keepalive_textbox").val(response['keepalive'])
             $("#setting_modal #peer_allowed_ip_textbox").val(response['allowed_ip'])
             $("#setting_modal #peer_endpoint_allowed_ips").val(response['endpoint_allowed_ip'])
             settingModal.toggle();
@@ -216,7 +220,7 @@ $("#save_peer_setting").click(function (){
     ){
         var peer_id = $(this).attr("peer_id");
         var conf_id = $(this).attr("conf_id");
-        var data_list = [$("#peer_name_textbox"), $("#peer_DNS_textbox"), $("#peer_private_key_textbox"), $("#peer_remote_endpoint_textbox"), $("#peer_allowed_ip_textbox"), $("#peer_endpoint_allowed_ips")]
+        var data_list = [$("#peer_name_textbox"), $("#peer_DNS_textbox"), $("#peer_private_key_textbox"), $("#peer_remote_endpoint_textbox"), $("#peer_mtu_textbox"), $("#peer_keepalive_textbox"), $("#peer_allowed_ip_textbox"), $("#peer_endpoint_allowed_ips")]
         for (var i = 0; i < data_list.length; i++){
             data_list[i].attr("disabled", "disabled")
         }
@@ -232,6 +236,8 @@ $("#save_peer_setting").click(function (){
                 DNS: $("#peer_DNS_textbox").val(),
                 private_key: $("#peer_private_key_textbox").val(),
                 remote_endpoint: $("#peer_remote_endpoint_textbox").val(),
+                mtu: $("#peer_mtu_textbox").val(),
+                keepalive: $("#peer_keepalive_textbox").val(),
                 allowed_ip: $("#peer_allowed_ip_textbox").val(),
                 endpoint_allowed_ip: $("#peer_endpoint_allowed_ips").val()
             }),

--- a/src/templates/configuration.html
+++ b/src/templates/configuration.html
@@ -81,6 +81,18 @@
                             </div>
                             <div class="col-sm-6">
                                  <div class="form-group">
+                                    <label for="new_add_mtu">MTU Size <code>(Default is 1420)</code></label>
+                                    <input type="text" class="form-control" id="new_add_mtu" value="{{ mtu }}">
+                                </div>
+                            </div>
+                            <div class="col-sm-6">
+                                 <div class="form-group">
+                                    <label for="new_add_mtu">Persistent Keepalive <code>(Time in seconds, default is Off)</code></label>
+                                    <input type="text" class="form-control" id="new_add_keepalive" value="{{ keepalive }}">
+                                </div>
+                            </div>
+                            <div class="col-sm-6">
+                                 <div class="form-group">
                                     <label for="new_add_endpoint_allowed_ip">Endpoint Allowed IPs <code>(Required)</code></label>
                                     <input type="text" class="form-control" id="new_add_endpoint_allowed_ip" value="{{ endpoint_allowed_ip }}">
                                 </div>
@@ -157,6 +169,14 @@
                     <div class="mb-3">
                       <label for="peer_remote_endpoint_textbox" class="form-label">Remote Endpoint <code>(Required)</code></label>
                       <input type="text" class="form-control" id="peer_remote_endpoint_textbox">
+                    </div>
+                    <div class="mb-3">
+                      <label for="peer_mtu_textbox" class="form-label">MTU Size <code>(Default is 1420)</code></label>
+                      <input type="text" class="form-control" id="peer_mtu_textbox">
+                    </div>
+                    <div class="mb-3">
+                      <label for="peer_keepalive_textbox" class="form-label">Persistent Keepalive <code>(Time in seconds, default is Off)</code></label>
+                      <input type="text" class="form-control" id="peer_keepalive_textbox">
                     </div>
                     <div class="mb-3">
                       <label for="peer_endpoint_allowed_ips" class="form-label">Endpoint Allowed IPs <code>(Required)</code></label>

--- a/src/templates/configuration.html
+++ b/src/templates/configuration.html
@@ -73,7 +73,12 @@
                                     <input type="text" class="form-control" id="new_add_DNS" value="{{ DNS }}">
                                 </div>
                             </div>
-
+                            <div class="col-sm-6">
+                                 <div class="form-group">
+                                    <label for="new_add_remote_endpoint">Remote Endpoint <code>(Required)</code></label>
+                                    <input type="text" class="form-control" id="new_add_remote_endpoint" value="{{ DNS }}">
+                                </div>
+                            </div>
                             <div class="col-sm-6">
                                  <div class="form-group">
                                     <label for="new_add_endpoint_allowed_ip">Endpoint Allowed IPs <code>(Required)</code></label>
@@ -144,11 +149,14 @@
                     <div class="mb-3">
                       <label for="peer_allowed_ip_textbox" class="form-label">Allowed IPs <code>(Required)</code></label>
                       <input type="text" class="form-control" id="peer_allowed_ip_textbox">
-
                     </div>
                     <div class="mb-3">
                       <label for="peer_DNS_textbox" class="form-label">DNS <code>(Required)</code></label>
                       <input type="text" class="form-control" id="peer_DNS_textbox">
+                    </div>
+                    <div class="mb-3">
+                      <label for="peer_remote_endpoint_textbox" class="form-label">Remote Endpoint <code>(Required)</code></label>
+                      <input type="text" class="form-control" id="peer_remote_endpoint_textbox">
                     </div>
                     <div class="mb-3">
                       <label for="peer_endpoint_allowed_ips" class="form-label">Endpoint Allowed IPs <code>(Required)</code></label>

--- a/src/templates/configuration.html
+++ b/src/templates/configuration.html
@@ -76,7 +76,7 @@
                             <div class="col-sm-6">
                                  <div class="form-group">
                                     <label for="new_add_remote_endpoint">Remote Endpoint <code>(Required)</code></label>
-                                    <input type="text" class="form-control" id="new_add_remote_endpoint" value="{{ DNS }}">
+                                    <input type="text" class="form-control" id="new_add_remote_endpoint" value="{{ remote_endpoint }}">
                                 </div>
                             </div>
                             <div class="col-sm-6">

--- a/src/templates/configuration.html
+++ b/src/templates/configuration.html
@@ -75,6 +75,12 @@
                             </div>
                             <div class="col-sm-6">
                                  <div class="form-group">
+                                    <label for="new_add_remote_endpoint">Remote Endpoint <code>(Required)</code></label>
+                                    <input type="text" class="form-control" id="new_add_remote_endpoint" value="{{ DNS }}">
+                                </div>
+                            </div>
+                            <div class="col-sm-6">
+                                 <div class="form-group">
                                     <label for="new_add_endpoint_allowed_ip">Endpoint Allowed IPs <code>(Required)</code></label>
                                     <input type="text" class="form-control" id="new_add_endpoint_allowed_ip" value="{{ endpoint_allowed_ip }}">
                                 </div>
@@ -147,6 +153,10 @@
                     <div class="mb-3">
                       <label for="peer_DNS_textbox" class="form-label">DNS <code>(Required)</code></label>
                       <input type="text" class="form-control" id="peer_DNS_textbox">
+                    </div>
+                    <div class="mb-3">
+                      <label for="peer_remote_endpoint_textbox" class="form-label">Remote Endpoint <code>(Required)</code></label>
+                      <input type="text" class="form-control" id="peer_remote_endpoint_textbox">
                     </div>
                     <div class="mb-3">
                       <label for="peer_endpoint_allowed_ips" class="form-label">Endpoint Allowed IPs <code>(Required)</code></label>

--- a/src/templates/configuration.html
+++ b/src/templates/configuration.html
@@ -75,12 +75,6 @@
                             </div>
                             <div class="col-sm-6">
                                  <div class="form-group">
-                                    <label for="new_add_remote_endpoint">Remote Endpoint <code>(Required)</code></label>
-                                    <input type="text" class="form-control" id="new_add_remote_endpoint" value="{{ DNS }}">
-                                </div>
-                            </div>
-                            <div class="col-sm-6">
-                                 <div class="form-group">
                                     <label for="new_add_endpoint_allowed_ip">Endpoint Allowed IPs <code>(Required)</code></label>
                                     <input type="text" class="form-control" id="new_add_endpoint_allowed_ip" value="{{ endpoint_allowed_ip }}">
                                 </div>
@@ -153,10 +147,6 @@
                     <div class="mb-3">
                       <label for="peer_DNS_textbox" class="form-label">DNS <code>(Required)</code></label>
                       <input type="text" class="form-control" id="peer_DNS_textbox">
-                    </div>
-                    <div class="mb-3">
-                      <label for="peer_remote_endpoint_textbox" class="form-label">Remote Endpoint <code>(Required)</code></label>
-                      <input type="text" class="form-control" id="peer_remote_endpoint_textbox">
                     </div>
                     <div class="mb-3">
                       <label for="peer_endpoint_allowed_ips" class="form-label">Endpoint Allowed IPs <code>(Required)</code></label>

--- a/src/templates/get_conf.html
+++ b/src/templates/get_conf.html
@@ -1,12 +1,12 @@
 <main role="main" class="col-md-9 ml-sm-auto col-lg-10 px-md-4 mt-4 mb-4">
-    <div class="info mt-4">
-        <div class="row">
-            <div class="col">
-                <small class="text-muted"><strong>CONFIGURATION</strong></small>
-                <h1 class="mb-3">{{conf_data['name']}}</h1>
-            </div>
-            <div class="col">
-                <small class="text-muted"><strong>ACTION</strong></small><br>
+	<div class="info mt-4">
+		<div class="row">
+			<div class="col">
+				<small class="text-muted"><strong>CONFIGURATION</strong></small>
+				<h1 class="mb-3">{{conf_data['name']}}</h1>
+			</div>
+			<div class="col">
+				<small class="text-muted"><strong>ACTION</strong></small><br>
                 {% if conf_data['checked'] == "checked" %}
                     <a href="#" id="{{conf_data['name']}}" {{conf_data['checked']}} class="switch text-primary"><i class="bi bi-toggle2-on"></i> ON</a>
                 {% else %}
@@ -15,47 +15,47 @@
                 <div class="spinner-border text-primary" role="status" style="display: none; margin-top: 10px">
                     <span class="sr-only">Loading...</span>
                 </div>
-            </div>
-            <div class="w-100"></div>
-            <div class="col">
-                <small class="text-muted"><strong>STATUS</strong></small>
-                <h6 style="text-transform: uppercase;">{{conf_data['status']}}<span class="dot dot-{{conf_data['status']}}"></span></h6>
-            </div>
-            <div class="col">
-                <small class="text-muted"><strong>CONNECTED PEERS</strong></small>
-                <h6 style="text-transform: uppercase;">{{conf_data['running_peer']}}</h6>
-            </div>
-            <div class="col-sm">
-                <small class="text-muted"><strong>TOTAL DATA USAGE</strong></small>
-                <h6 style="text-transform: uppercase;">{{conf_data['total_data_usage'][0]}} GB</h6>
-            </div>
-            <div class="col-sm">
-                <small class="text-muted"><strong>TOTAL RECIEVED</strong></small>
-                <h6 style="text-transform: uppercase;">{{conf_data['total_data_usage'][1]}} GB</h6>
-            </div>
-            <div class="col-sm">
-                <small class="text-muted"><strong>TOTAL SENT</strong></small>
-                <h6 style="text-transform: uppercase;">{{conf_data['total_data_usage'][2]}} GB</h6>
-            </div>
-            <div class="w-100"></div>
-            <div class="col-sm">
-                <small class="text-muted">
+			</div>
+			<div class="w-100"></div>
+			<div class="col">
+				<small class="text-muted"><strong>STATUS</strong></small>
+				<h6 style="text-transform: uppercase;">{{conf_data['status']}}<span class="dot dot-{{conf_data['status']}}"></span></h6>
+			</div>
+			<div class="col">
+				<small class="text-muted"><strong>CONNECTED PEERS</strong></small>
+				<h6 style="text-transform: uppercase;">{{conf_data['running_peer']}}</h6>
+			</div>
+			<div class="col-sm">
+				<small class="text-muted"><strong>TOTAL DATA USAGE</strong></small>
+				<h6 style="text-transform: uppercase;">{{conf_data['total_data_usage'][0]}} GB</h6>
+			</div>
+			<div class="col-sm">
+				<small class="text-muted"><strong>TOTAL RECIEVED</strong></small>
+				<h6 style="text-transform: uppercase;">{{conf_data['total_data_usage'][1]}} GB</h6>
+			</div>
+			<div class="col-sm">
+				<small class="text-muted"><strong>TOTAL SENT</strong></small>
+				<h6 style="text-transform: uppercase;">{{conf_data['total_data_usage'][2]}} GB</h6>
+			</div>
+			<div class="w-100"></div>
+			<div class="col-sm">
+				<small class="text-muted">
                     <strong>PUBLIC KEY</strong>
                     <strong style="margin-left: auto!important; opacity: 0; transition: 0.2s ease-in-out" class="text-primary">CLICK TO COPY</strong></small>
                 </small>
-                <h6 style="text-transform: uppercase;"><samp class="key">{{conf_data['public_key']}}</samp></h6>
-            </div>
+				<h6 style="text-transform: uppercase;"><samp class="key">{{conf_data['public_key']}}</samp></h6>
+			</div>
+			<div class="col-sm">
+				<small class="text-muted"><strong>LISTEN PORT</strong></small>
+				<h6 style="text-transform: uppercase;"><samp>{{conf_data['listen_port']}}</samp></h6>
+			</div>
             <div class="col-sm">
-                <small class="text-muted"><strong>LISTEN PORT</strong></small>
-                <h6 style="text-transform: uppercase;"><samp>{{conf_data['listen_port']}}</samp></h6>
-            </div>
-            <div class="col-sm">
-                <small class="text-muted"><strong>ADDRESS</strong></small>
-                <h6 style="text-transform: uppercase;"><samp>{{conf_data['conf_address']}}</samp></h6>
-            </div>
-        </div>
-        <hr>
-        <div class="button-div mb-3">
+				<small class="text-muted"><strong>ADDRESS</strong></small>
+				<h6 style="text-transform: uppercase;"><samp>{{conf_data['conf_address']}}</samp></h6>
+			</div>
+		</div>
+		<hr>
+		<div class="button-div mb-3">
             <div class="row">
                 <div class="col-sm">
                      <div class="form-group">
@@ -89,8 +89,8 @@
                 </div>
             </div>
             <hr>
-        </div>
-    </div>
+		</div>
+	</div>
 
     <div class="row">
         {% if conf_data['peer_data']|length == 0 %}
@@ -139,7 +139,7 @@
                         </div>
                         <div class="w-100"></div>
                         <div class="col-sm">
-                            <small class="text-muted"><strong>LOCAL ENDPOINT</strong></small>
+                            <small class="text-muted"><strong>END POINT</strong></small>
                             <h6 style="text-transform: uppercase;">{{i['endpoint']}}</h6>
                         </div>
                         <div class="w-100"></div>
@@ -151,7 +151,7 @@
                                 <button type="button" class="btn btn-outline-danger btn-delete-peer btn-control" id="{{i['id']}}" data-toggle="modal"><i class="bi bi-x-circle-fill"></i></button>
                                 {% if i['private_key'] %}
                                     <div class="share_peer_btn_group" style="margin-left: auto !important; display: inline">
-                                        <button type="button" class="btn btn-outline-success btn-qrcode-peer btn-control" img_src="{{ qrcode("[Interface]\nPrivateKey = "+i['private_key']+"\nAddress = "+i['allowed_ip']+"\nDNS = "+i['DNS']+"\n\n[Peer]\nPublicKey = "+conf_data['public_key']+"\nAllowedIPs = "+i['endpoint_allowed_ip']+"\nEndpoint = "+i['remote_endpoint']+":"+conf_data['listen_port']) }}">
+                                        <button type="button" class="btn btn-outline-success btn-qrcode-peer btn-control" img_src="{{ qrcode("[Interface]\nPrivateKey = "+i['private_key']+"\nAddress = "+i['allowed_ip']+"\nDNS = "+i['DNS']+"\n\n[Peer]\nPublicKey = "+conf_data['public_key']+"\nAllowedIPs = "+i['endpoint_allowed_ip']+"\nEndpoint = "+wg_ip+":"+conf_data['listen_port']) }}">
                                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="width: 19px;" fill="#28a745"><path d="M3 11h8V3H3v8zm2-6h4v4H5V5zM3 21h8v-8H3v8zm2-6h4v4H5v-4zM13 3v8h8V3h-8zm6 6h-4V5h4v4zM13 13h2v2h-2zM15 15h2v2h-2zM13 17h2v2h-2zM17 17h2v2h-2zM19 19h2v2h-2zM15 19h2v2h-2zM17 13h2v2h-2zM19 15h2v2h-2z"/></svg>
                                         </button>
                                         <a href="/download/{{ conf_data['name'] }}?id={{ i['id']|urlencode }}" class="btn btn-outline-info btn-download-peer btn-control">

--- a/src/templates/get_conf.html
+++ b/src/templates/get_conf.html
@@ -1,12 +1,12 @@
 <main role="main" class="col-md-9 ml-sm-auto col-lg-10 px-md-4 mt-4 mb-4">
-	<div class="info mt-4">
-		<div class="row">
-			<div class="col">
-				<small class="text-muted"><strong>CONFIGURATION</strong></small>
-				<h1 class="mb-3">{{conf_data['name']}}</h1>
-			</div>
-			<div class="col">
-				<small class="text-muted"><strong>ACTION</strong></small><br>
+    <div class="info mt-4">
+        <div class="row">
+            <div class="col">
+                <small class="text-muted"><strong>CONFIGURATION</strong></small>
+                <h1 class="mb-3">{{conf_data['name']}}</h1>
+            </div>
+            <div class="col">
+                <small class="text-muted"><strong>ACTION</strong></small><br>
                 {% if conf_data['checked'] == "checked" %}
                     <a href="#" id="{{conf_data['name']}}" {{conf_data['checked']}} class="switch text-primary"><i class="bi bi-toggle2-on"></i> ON</a>
                 {% else %}
@@ -15,47 +15,47 @@
                 <div class="spinner-border text-primary" role="status" style="display: none; margin-top: 10px">
                     <span class="sr-only">Loading...</span>
                 </div>
-			</div>
-			<div class="w-100"></div>
-			<div class="col">
-				<small class="text-muted"><strong>STATUS</strong></small>
-				<h6 style="text-transform: uppercase;">{{conf_data['status']}}<span class="dot dot-{{conf_data['status']}}"></span></h6>
-			</div>
-			<div class="col">
-				<small class="text-muted"><strong>CONNECTED PEERS</strong></small>
-				<h6 style="text-transform: uppercase;">{{conf_data['running_peer']}}</h6>
-			</div>
-			<div class="col-sm">
-				<small class="text-muted"><strong>TOTAL DATA USAGE</strong></small>
-				<h6 style="text-transform: uppercase;">{{conf_data['total_data_usage'][0]}} GB</h6>
-			</div>
-			<div class="col-sm">
-				<small class="text-muted"><strong>TOTAL RECIEVED</strong></small>
-				<h6 style="text-transform: uppercase;">{{conf_data['total_data_usage'][1]}} GB</h6>
-			</div>
-			<div class="col-sm">
-				<small class="text-muted"><strong>TOTAL SENT</strong></small>
-				<h6 style="text-transform: uppercase;">{{conf_data['total_data_usage'][2]}} GB</h6>
-			</div>
-			<div class="w-100"></div>
-			<div class="col-sm">
-				<small class="text-muted">
+            </div>
+            <div class="w-100"></div>
+            <div class="col">
+                <small class="text-muted"><strong>STATUS</strong></small>
+                <h6 style="text-transform: uppercase;">{{conf_data['status']}}<span class="dot dot-{{conf_data['status']}}"></span></h6>
+            </div>
+            <div class="col">
+                <small class="text-muted"><strong>CONNECTED PEERS</strong></small>
+                <h6 style="text-transform: uppercase;">{{conf_data['running_peer']}}</h6>
+            </div>
+            <div class="col-sm">
+                <small class="text-muted"><strong>TOTAL DATA USAGE</strong></small>
+                <h6 style="text-transform: uppercase;">{{conf_data['total_data_usage'][0]}} GB</h6>
+            </div>
+            <div class="col-sm">
+                <small class="text-muted"><strong>TOTAL RECIEVED</strong></small>
+                <h6 style="text-transform: uppercase;">{{conf_data['total_data_usage'][1]}} GB</h6>
+            </div>
+            <div class="col-sm">
+                <small class="text-muted"><strong>TOTAL SENT</strong></small>
+                <h6 style="text-transform: uppercase;">{{conf_data['total_data_usage'][2]}} GB</h6>
+            </div>
+            <div class="w-100"></div>
+            <div class="col-sm">
+                <small class="text-muted">
                     <strong>PUBLIC KEY</strong>
                     <strong style="margin-left: auto!important; opacity: 0; transition: 0.2s ease-in-out" class="text-primary">CLICK TO COPY</strong></small>
                 </small>
-				<h6 style="text-transform: uppercase;"><samp class="key">{{conf_data['public_key']}}</samp></h6>
-			</div>
-			<div class="col-sm">
-				<small class="text-muted"><strong>LISTEN PORT</strong></small>
-				<h6 style="text-transform: uppercase;"><samp>{{conf_data['listen_port']}}</samp></h6>
-			</div>
+                <h6 style="text-transform: uppercase;"><samp class="key">{{conf_data['public_key']}}</samp></h6>
+            </div>
             <div class="col-sm">
-				<small class="text-muted"><strong>ADDRESS</strong></small>
-				<h6 style="text-transform: uppercase;"><samp>{{conf_data['conf_address']}}</samp></h6>
-			</div>
-		</div>
-		<hr>
-		<div class="button-div mb-3">
+                <small class="text-muted"><strong>LISTEN PORT</strong></small>
+                <h6 style="text-transform: uppercase;"><samp>{{conf_data['listen_port']}}</samp></h6>
+            </div>
+            <div class="col-sm">
+                <small class="text-muted"><strong>ADDRESS</strong></small>
+                <h6 style="text-transform: uppercase;"><samp>{{conf_data['conf_address']}}</samp></h6>
+            </div>
+        </div>
+        <hr>
+        <div class="button-div mb-3">
             <div class="row">
                 <div class="col-sm">
                      <div class="form-group">
@@ -89,8 +89,8 @@
                 </div>
             </div>
             <hr>
-		</div>
-	</div>
+        </div>
+    </div>
 
     <div class="row">
         {% if conf_data['peer_data']|length == 0 %}
@@ -139,7 +139,7 @@
                         </div>
                         <div class="w-100"></div>
                         <div class="col-sm">
-                            <small class="text-muted"><strong>END POINT</strong></small>
+                            <small class="text-muted"><strong>LOCAL ENDPOINT</strong></small>
                             <h6 style="text-transform: uppercase;">{{i['endpoint']}}</h6>
                         </div>
                         <div class="w-100"></div>
@@ -151,7 +151,7 @@
                                 <button type="button" class="btn btn-outline-danger btn-delete-peer btn-control" id="{{i['id']}}" data-toggle="modal"><i class="bi bi-x-circle-fill"></i></button>
                                 {% if i['private_key'] %}
                                     <div class="share_peer_btn_group" style="margin-left: auto !important; display: inline">
-                                        <button type="button" class="btn btn-outline-success btn-qrcode-peer btn-control" img_src="{{ qrcode("[Interface]\nPrivateKey = "+i['private_key']+"\nAddress = "+i['allowed_ip']+"\nDNS = "+i['DNS']+"\n\n[Peer]\nPublicKey = "+conf_data['public_key']+"\nAllowedIPs = "+i['endpoint_allowed_ip']+"\nEndpoint = "+wg_ip+":"+conf_data['listen_port']) }}">
+                                        <button type="button" class="btn btn-outline-success btn-qrcode-peer btn-control" img_src="{{ qrcode("[Interface]\nPrivateKey = "+i['private_key']+"\nAddress = "+i['allowed_ip']+"\nDNS = "+i['DNS']+"\n\n[Peer]\nPublicKey = "+conf_data['public_key']+"\nAllowedIPs = "+i['endpoint_allowed_ip']+"\nEndpoint = "+i['remote_endpoint']+":"+conf_data['listen_port']) }}">
                                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="width: 19px;" fill="#28a745"><path d="M3 11h8V3H3v8zm2-6h4v4H5V5zM3 21h8v-8H3v8zm2-6h4v4H5v-4zM13 3v8h8V3h-8zm6 6h-4V5h4v4zM13 13h2v2h-2zM15 15h2v2h-2zM13 17h2v2h-2zM17 17h2v2h-2zM19 19h2v2h-2zM15 19h2v2h-2zM17 13h2v2h-2zM19 15h2v2h-2z"/></svg>
                                         </button>
                                         <a href="/download/{{ conf_data['name'] }}?id={{ i['id']|urlencode }}" class="btn btn-outline-info btn-download-peer btn-control">

--- a/src/templates/get_conf.html
+++ b/src/templates/get_conf.html
@@ -139,7 +139,7 @@
                         </div>
                         <div class="w-100"></div>
                         <div class="col-sm">
-                            <small class="text-muted"><strong>END POINT</strong></small>
+                            <small class="text-muted"><strong>LOCAL ENDPOINT</strong></small>
                             <h6 style="text-transform: uppercase;">{{i['endpoint']}}</h6>
                         </div>
                         <div class="w-100"></div>
@@ -151,7 +151,7 @@
                                 <button type="button" class="btn btn-outline-danger btn-delete-peer btn-control" id="{{i['id']}}" data-toggle="modal"><i class="bi bi-x-circle-fill"></i></button>
                                 {% if i['private_key'] %}
                                     <div class="share_peer_btn_group" style="margin-left: auto !important; display: inline">
-                                        <button type="button" class="btn btn-outline-success btn-qrcode-peer btn-control" img_src="{{ qrcode("[Interface]\nPrivateKey = "+i['private_key']+"\nAddress = "+i['allowed_ip']+"\nDNS = "+i['DNS']+"\n\n[Peer]\nPublicKey = "+conf_data['public_key']+"\nAllowedIPs = "+i['endpoint_allowed_ip']+"\nEndpoint = "+wg_ip+":"+conf_data['listen_port']) }}">
+                                        <button type="button" class="btn btn-outline-success btn-qrcode-peer btn-control" img_src="{{ qrcode("[Interface]\nPrivateKey = "+i['private_key']+"\nAddress = "+i['allowed_ip']+"\nDNS = "+i['DNS']+"\n\n[Peer]\nPublicKey = "+conf_data['public_key']+"\nAllowedIPs = "+i['endpoint_allowed_ip']+"\nEndpoint = "+i['remote_endpoint']+":"+conf_data['listen_port']) }}">
                                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="width: 19px;" fill="#28a745"><path d="M3 11h8V3H3v8zm2-6h4v4H5V5zM3 21h8v-8H3v8zm2-6h4v4H5v-4zM13 3v8h8V3h-8zm6 6h-4V5h4v4zM13 13h2v2h-2zM15 15h2v2h-2zM13 17h2v2h-2zM17 17h2v2h-2zM19 19h2v2h-2zM15 19h2v2h-2zM17 13h2v2h-2zM19 15h2v2h-2z"/></svg>
                                         </button>
                                         <a href="/download/{{ conf_data['name'] }}?id={{ i['id']|urlencode }}" class="btn btn-outline-info btn-download-peer btn-control">

--- a/src/templates/get_conf.html
+++ b/src/templates/get_conf.html
@@ -150,14 +150,51 @@
                                 <button type="button" class="btn btn-outline-primary btn-setting-peer btn-control" id="{{i['id']}}" data-toggle="modal"><i class="bi bi-gear-fill"></i></button>
                                 <button type="button" class="btn btn-outline-danger btn-delete-peer btn-control" id="{{i['id']}}" data-toggle="modal"><i class="bi bi-x-circle-fill"></i></button>
                                 {% if i['private_key'] %}
-                                    <div class="share_peer_btn_group" style="margin-left: auto !important; display: inline">
-                                        <button type="button" class="btn btn-outline-success btn-qrcode-peer btn-control" img_src="{{ qrcode("[Interface]\nPrivateKey = "+i['private_key']+"\nAddress = "+i['allowed_ip']+"\nDNS = "+i['DNS']+"\n\n[Peer]\nPublicKey = "+conf_data['public_key']+"\nAllowedIPs = "+i['endpoint_allowed_ip']+"\nEndpoint = "+i['remote_endpoint']+":"+conf_data['listen_port']) }}">
-                                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="width: 19px;" fill="#28a745"><path d="M3 11h8V3H3v8zm2-6h4v4H5V5zM3 21h8v-8H3v8zm2-6h4v4H5v-4zM13 3v8h8V3h-8zm6 6h-4V5h4v4zM13 13h2v2h-2zM15 15h2v2h-2zM13 17h2v2h-2zM17 17h2v2h-2zM19 19h2v2h-2zM15 19h2v2h-2zM17 13h2v2h-2zM19 15h2v2h-2z"/></svg>
-                                        </button>
-                                        <a href="/download/{{ conf_data['name'] }}?id={{ i['id']|urlencode }}" class="btn btn-outline-info btn-download-peer btn-control">
-                                            <i class="bi bi-download"></i>
-                                        </a>
-                                    </div>
+                                    {% if i['mtu'] %}
+                                        {% if i['keepalive'] %}
+                                            <div class="share_peer_btn_group" style="margin-left: auto !important; display: inline">
+                                                <button type="button" class="btn btn-outline-success btn-qrcode-peer btn-control" img_src="{{ qrcode("[Interface]\nPrivateKey = "+i['private_key']+"\nAddress = "+i['allowed_ip']+"\nDNS = "+i['DNS']+"\nMTU ="+i['mtu']+"\n\n[Peer]\nPublicKey = "+conf_data['public_key']+"\nAllowedIPs = "+i['endpoint_allowed_ip']+"\nPersistentKeepalive = "+i['keepalive']+"\nEndpoint = "+i['remote_endpoint']+":"+conf_data['listen_port']) }}">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="width: 19px;" fill="#28a745"><path d="M3 11h8V3H3v8zm2-6h4v4H5V5zM3 21h8v-8H3v8zm2-6h4v4H5v-4zM13 3v8h8V3h-8zm6 6h-4V5h4v4zM13 13h2v2h-2zM15 15h2v2h-2zM13 17h2v2h-2zM17 17h2v2h-2zM19 19h2v2h-2zM15 19h2v2h-2zM17 13h2v2h-2zM19 15h2v2h-2z"/></svg>
+                                                </button>
+                                                <a href="/download/{{ conf_data['name'] }}?id={{ i['id']|urlencode }}" class="btn btn-outline-info btn-download-peer btn-control">
+                                                    <i class="bi bi-download"></i>
+                                                </a>
+                                            </div>
+                                        {% else %}
+                                            <div class="share_peer_btn_group" style="margin-left: auto !important; display: inline">
+                                                <button type="button" class="btn btn-outline-success btn-qrcode-peer btn-control" img_src="{{ qrcode("[Interface]\nPrivateKey = "+i['private_key']+"\nAddress = "+i['allowed_ip']+"\nDNS = "+i['DNS']+"\nMTU ="+i['mtu']+"\n\n[Peer]\nPublicKey = "+conf_data['public_key']+"\nAllowedIPs = "+i['endpoint_allowed_ip']+"\nEndpoint = "+i['remote_endpoint']+":"+conf_data['listen_port']) }}">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="width: 19px;" fill="#28a745"><path d="M3 11h8V3H3v8zm2-6h4v4H5V5zM3 21h8v-8H3v8zm2-6h4v4H5v-4zM13 3v8h8V3h-8zm6 6h-4V5h4v4zM13 13h2v2h-2zM15 15h2v2h-2zM13 17h2v2h-2zM17 17h2v2h-2zM19 19h2v2h-2zM15 19h2v2h-2zM17 13h2v2h-2zM19 15h2v2h-2z"/></svg>
+                                                </button>
+                                                <a href="/download/{{ conf_data['name'] }}?id={{ i['id']|urlencode }}" class="btn btn-outline-info btn-download-peer btn-control">
+                                                    <i class="bi bi-download"></i>
+                                                </a>
+                                            </div>
+                                        {% endif %}
+                                    {% endif %}
+                                    {% if i['keepalive'] %}
+                                        {% if i['mtu'] == "" %}
+                                            <div class="share_peer_btn_group" style="margin-left: auto !important; display: inline">
+                                                <button type="button" class="btn btn-outline-success btn-qrcode-peer btn-control" img_src="{{ qrcode("[Interface]\nPrivateKey = "+i['private_key']+"\nAddress = "+i['allowed_ip']+"\nDNS = "+i['DNS']+"\n\n[Peer]\nPublicKey = "+conf_data['public_key']+"\nAllowedIPs = "+i['endpoint_allowed_ip']+"\nPersistentKeepalive = "+i['keepalive']+"\nEndpoint = "+i['remote_endpoint']+":"+conf_data['listen_port']) }}">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="width: 19px;" fill="#28a745"><path d="M3 11h8V3H3v8zm2-6h4v4H5V5zM3 21h8v-8H3v8zm2-6h4v4H5v-4zM13 3v8h8V3h-8zm6 6h-4V5h4v4zM13 13h2v2h-2zM15 15h2v2h-2zM13 17h2v2h-2zM17 17h2v2h-2zM19 19h2v2h-2zM15 19h2v2h-2zM17 13h2v2h-2zM19 15h2v2h-2z"/></svg>
+                                                </button>
+                                                <a href="/download/{{ conf_data['name'] }}?id={{ i['id']|urlencode }}" class="btn btn-outline-info btn-download-peer btn-control">
+                                                    <i class="bi bi-download"></i>
+                                                </a>
+                                            </div>
+                                        {% endif %}
+                                    {% endif %}
+                                    {% if i['mtu'] == "" %}
+                                        {% if i['keepalive'] == "" %}
+                                            <div class="share_peer_btn_group" style="margin-left: auto !important; display: inline">
+                                                <button type="button" class="btn btn-outline-success btn-qrcode-peer btn-control" img_src="{{ qrcode("[Interface]\nPrivateKey = "+i['private_key']+"\nAddress = "+i['allowed_ip']+"\nDNS = "+i['DNS']+"\n\n[Peer]\nPublicKey = "+conf_data['public_key']+"\nAllowedIPs = "+i['endpoint_allowed_ip']+"\nEndpoint = "+i['remote_endpoint']+":"+conf_data['listen_port']) }}">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="width: 19px;" fill="#28a745"><path d="M3 11h8V3H3v8zm2-6h4v4H5V5zM3 21h8v-8H3v8zm2-6h4v4H5v-4zM13 3v8h8V3h-8zm6 6h-4V5h4v4zM13 13h2v2h-2zM15 15h2v2h-2zM13 17h2v2h-2zM17 17h2v2h-2zM19 19h2v2h-2zM15 19h2v2h-2zM17 13h2v2h-2zM19 15h2v2h-2z"/></svg>
+                                                </button>
+                                                <a href="/download/{{ conf_data['name'] }}?id={{ i['id']|urlencode }}" class="btn btn-outline-info btn-download-peer btn-control">
+                                                    <i class="bi bi-download"></i>
+                                                </a>
+                                            </div>
+                                        {% endif %}
+                                    {% endif %}
                                 {% endif %}
                             </div>
                         </div>

--- a/src/templates/get_conf.html
+++ b/src/templates/get_conf.html
@@ -133,14 +133,13 @@
                             <h6 style="text-transform: uppercase;">{{i['allowed_ip']}}</h6>
                         </div>
                         <div class="w-100"></div>
-
                         <div class="col-sm">
                             <small class="text-muted"><strong>LATEST HANDSHAKE</strong></small>
                             <h6 style="text-transform: uppercase;">{{i['latest_handshake']}}</h6>
                         </div>
                         <div class="w-100"></div>
                         <div class="col-sm">
-                            <small class="text-muted"><strong>END POINT</strong></small>
+                            <small class="text-muted"><strong>LOCAL ENDPOINT</strong></small>
                             <h6 style="text-transform: uppercase;">{{i['endpoint']}}</h6>
                         </div>
                         <div class="w-100"></div>
@@ -152,7 +151,7 @@
                                 <button type="button" class="btn btn-outline-danger btn-delete-peer btn-control" id="{{i['id']}}" data-toggle="modal"><i class="bi bi-x-circle-fill"></i></button>
                                 {% if i['private_key'] %}
                                     <div class="share_peer_btn_group" style="margin-left: auto !important; display: inline">
-                                        <button type="button" class="btn btn-outline-success btn-qrcode-peer btn-control" img_src="{{ qrcode("[Interface]\nPrivateKey = "+i['private_key']+"\nAddress = "+i['allowed_ip']+"\nDNS = "+i['DNS']+"\n\n[Peer]\nPublicKey = "+conf_data['public_key']+"\nAllowedIPs = "+i['endpoint_allowed_ip']+"\nEndpoint = "+wg_ip+":"+conf_data['listen_port']) }}">
+                                        <button type="button" class="btn btn-outline-success btn-qrcode-peer btn-control" img_src="{{ qrcode("[Interface]\nPrivateKey = "+i['private_key']+"\nAddress = "+i['allowed_ip']+"\nDNS = "+i['DNS']+"\n\n[Peer]\nPublicKey = "+conf_data['public_key']+"\nAllowedIPs = "+i['endpoint_allowed_ip']+"\nEndpoint = "+i['remote_endpoint']+":"+conf_data['listen_port']) }}">
                                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="width: 19px;" fill="#28a745"><path d="M3 11h8V3H3v8zm2-6h4v4H5V5zM3 21h8v-8H3v8zm2-6h4v4H5v-4zM13 3v8h8V3h-8zm6 6h-4V5h4v4zM13 13h2v2h-2zM15 15h2v2h-2zM13 17h2v2h-2zM17 17h2v2h-2zM19 19h2v2h-2zM15 19h2v2h-2zM17 13h2v2h-2zM19 15h2v2h-2z"/></svg>
                                         </button>
                                         <a href="/download/{{ conf_data['name'] }}?id={{ i['id']|urlencode }}" class="btn btn-outline-info btn-download-peer btn-control">

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -36,6 +36,13 @@
                                        value="{{ peer_global_DNS }}" required>
                             </div>
                             <div class="col-sm">
+                                <label for="username">Peer Endpoint</label>
+                                <input type="text" class="form-control mb-4" id="peer_remote_endpoint" name="peer_remote_endpoint"
+                                       value="{{ peer_remote_endpoint }}" required>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-sm">
                                 <label for="username">Peer Endpoint Allowed IPs</label>
                                 <input type="text" class="form-control mb-4" id="peer_endpoint_allowed_ip" name="peer_endpoint_allowed_ip"
                                        value="{{ peer_endpoint_allowed_ip }}" required>

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -36,13 +36,6 @@
                                        value="{{ peer_global_DNS }}" required>
                             </div>
                             <div class="col-sm">
-                                <label for="username">Peer Endpoint</label>
-                                <input type="text" class="form-control mb-4" id="peer_remote_endpoint" name="peer_remote_endpoint"
-                                       value="{{ peer_remote_endpoint }}" required>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-sm">
                                 <label for="username">Peer Endpoint Allowed IPs</label>
                                 <input type="text" class="form-control mb-4" id="peer_endpoint_allowed_ip" name="peer_endpoint_allowed_ip"
                                        value="{{ peer_endpoint_allowed_ip }}" required>


### PR DESCRIPTION
Kinda got carried away here. The Remote Peer is on the global settings page, the MTU and PersistentKeepalives are set on the peer config page. The settings also appear on the new peer page too.

The Remote Peer endpoint can be an IP, hostname or FQDN and it seems to work fine.

This covers issues #60, #61 and #62. You can probably find ways of making this much tidier.